### PR TITLE
Added Option for Installation without APT or Yum

### DIFF
--- a/jobs/cp_halo/spec
+++ b/jobs/cp_halo/spec
@@ -10,7 +10,10 @@ properties:
     description: agent server tag
   cp_halo.aws_server_label:
     description: use the combination of aws account id and instance id as server_label. Takes (True/False)
-    default: 1
+    default:
+  cp_halo.binary_install:
+    description: If set to 1, bosh will use binaries to run halo
+    default: 0
 
 templates:
   bin/ctl: bin/ctl
@@ -18,3 +21,4 @@ templates:
   data/properties.sh.erb: data/properties.sh
   helpers/ctl_setup.sh: helpers/ctl_setup.sh
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
+  bin/init.d: bin/cphalod

--- a/jobs/cp_halo/spec
+++ b/jobs/cp_halo/spec
@@ -10,7 +10,7 @@ properties:
     description: agent server tag
   cp_halo.aws_server_label:
     description: use the combination of aws account id and instance id as server_label. Takes (True/False)
-    default:
+    default: 2
   cp_halo.binary_install:
     description: If set to 1, bosh will use binaries to run halo
     default: 0

--- a/jobs/cp_halo/templates/bin/ctl
+++ b/jobs/cp_halo/templates/bin/ctl
@@ -34,14 +34,23 @@ install_yum() {
     pidof cphalo > $PIDFILE
 }
 
+install_binary() {
+    server_label=$1
+    sudo /var/vcap/packages/cp_halo/bin/configure --agent-key=$AGENT_KEY --grid=https://grid.cloudpassage.com/grid --server-label=$server_label $tag >> $LOG_DIR/$JOB_NAME.log 2>&1
+    sudo /var/vcap/jobs/cp_halo/bin/cphalod start >> $LOG_DIR/$JOB_NAME.log 2>&1
+    pidof cphalo > $PIDFILE
+}
+
 case $1 in
 
   start)
     platform="$(cat /etc/*-release | grep -w ID)"
-    if [ $AWS_SERVER_LABEL == 0 ]  ; then
+    if [ $AWS_SERVER_LABEL == 0 ]; then
         account_id=$(curl -fs http://169.254.169.254/latest/dynamic/instance-identity/document/ | python -c "import json,sys;obj=json.load(sys.stdin);print obj['accountId']")
         instance_id=$(curl -fs http://169.254.169.254/latest/dynamic/instance-identity/document/ | python -c "import json,sys;obj=json.load(sys.stdin);print obj['instanceId']")
         server_label=$account_id\_$instance_id
+    elif [ $AWS_SERVER_LABEL == 1 ]; then
+        server_label=$NAME\_$JOB_INDEX
     else
         server_label="$(hostname)"
     fi
@@ -52,7 +61,9 @@ case $1 in
         tag="--tag=$SERVER_TAG"
     fi
 
-    if [[ $platform == *"ubuntu"* || $platform == *"debian"* ]]; then
+    if [ $BINARY_INSTALL == 1 ]; then
+        install_binary $server_label $tag
+    elif [[ $platform == *"ubuntu"* || $platform == *"debian"* ]]; then
         install_deb $server_label $tag
     else
         install_yum $server_label $tag

--- a/jobs/cp_halo/templates/bin/init.d
+++ b/jobs/cp_halo/templates/bin/init.d
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:             cphalod
+# Required-Start:       $local_fs $remote_fs $network $named
+# Required-Stop:        $remote_fs $syslog
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    CloudPassage Halo Agent
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+CP='/var/vcap/packages/cp_halo'
+
+start()
+{
+    status_of_proc -p $CP/data/halo.pid $CP/bin/cphalo cphalod > /dev/null
+    if [ $? = 0 ]; then
+      log_success_msg "The CloudPassage Halo Agent is already running"
+      exit 0
+    fi
+
+    if [ ! -f "$CP/data/store.db.vector" ]; then
+      if [ ! -f "$CP/data/cphalo.properties" ]; then
+        log_failure_msg "Please run $CP/bin/configure"
+        exit 1
+      fi
+      DAEMON_KEY=`grep "^daemon-key=[0-9a-f]*$" $CP/data/cphalo.properties`
+      if [ "$DAEMON_KEY" = '' ] || [ `expr length "$DAEMON_KEY"` -ne 43 ]; then
+        log_failure_msg "Please run $CP/bin/configure and specify your agent key"
+        exit 1
+      fi
+    fi
+
+    log_daemon_msg "Starting CloudPassage Halo Agent" "cphalo"
+
+    if start-stop-daemon --start --quiet --oknodo --pidfile $CP/data/halo.pid --exec $CP/bin/cphalo -- --daemon --pidfile=$CP/data/halo.pid; then
+      log_end_msg 0
+    else
+      log_end_msg 1
+    fi
+
+}
+
+stop()
+{
+    log_daemon_msg "Stopping CloudPassage Halo Agent" "cphalo"
+    if start-stop-daemon --stop --quiet --retry=TERM/5/KILL/5 --pidfile $CP/data/halo.pid --name cphalo; then
+      start-stop-daemon --stop --quiet --retry=TERM/5/KILL/5 --name cphalow
+      log_end_msg 0
+    else
+      log_end_msg 1
+    fi
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+         status_of_proc -p $CP/data/halo.pid $CP/bin/cphalo cphalod && exit 0 || exit $?
+        ;;
+    restart|force-reload)
+        start-stop-daemon --stop --quiet --retry=TERM/5/KILL/5 --pidfile $CP/data/halo.pid --name cphalo
+        start-stop-daemon --stop --quiet --retry=TERM/5/KILL/5 --name cphalow
+        start
+        ;;
+    *)
+        echo "Usage: /etc/init.d/cphalod {start|stop|restart|status}"
+        exit 1
+esac
+
+exit 0

--- a/jobs/cp_halo/templates/data/properties.sh.erb
+++ b/jobs/cp_halo/templates/data/properties.sh.erb
@@ -11,3 +11,4 @@ export JOB_FULL="$NAME/$JOB_INDEX"
 export AGENT_KEY=<%= p("cp_halo.agent_key") %>
 export SERVER_TAG=<%= p("cp_halo.server_tag") %>
 export AWS_SERVER_LABEL=<%= p("cp_halo.aws_server_label") %>
+export BINARY_INSTALL=<%= p("cp_halo.binary_install") %>

--- a/jobs/cp_halo/templates/helpers/ctl_setup.sh
+++ b/jobs/cp_halo/templates/helpers/ctl_setup.sh
@@ -90,3 +90,6 @@ done
 PIDFILE=$RUN_DIR/$output_label.pid
 
 echo '$PATH' $PATH
+
+mkdir -p /opt/cloudpassage
+mkdir -p /opt/cloudpassage/data

--- a/packages/cp_halo/packaging
+++ b/packages/cp_halo/packaging
@@ -1,3 +1,21 @@
-# abort script on any command that exits with a non zero value
-set -e
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
 
+# Detect # of CPUs so make jobs can be parallelized
+CPUS=$(grep -c ^processor /proc/cpuinfo)
+ # Available variables
+# $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
+# $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
+export HOME=/var/vcap
+
+tar xfv cp_halo/cloudpassage.tgz
+
+mkdir $BOSH_INSTALL_TARGET/bin
+mkdir $BOSH_INSTALL_TARGET/data
+mkdir $BOSH_INSTALL_TARGET/log
+
+# cd configure
+# ./configure --prefix=${BOSH_INSTALL_TARGET}
+# make -j${CPUS} && make install
+# Alternatively, to copy archive contents:
+cp -a * $BOSH_INSTALL_TARGET/bin

--- a/packages/cp_halo/spec
+++ b/packages/cp_halo/spec
@@ -1,5 +1,5 @@
 ---
 name: cp_halo
-
+dependencies: []
 files:
-  - cp_halo
+- cp_halo/cloudpassage.tgz


### PR DESCRIPTION
Hello,

Using Yum and APT to install packages can cause problems when using BOSH. So, I added an option to use the binary installation to run Cloud Passage Halo. I also added an extra option for server_label, so this bosh release can be used in other infrastructures such as Azure and VSphere.

Thanks,
Van